### PR TITLE
edit script to build before start

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "src/app.js",
   "scripts": {
     "build": "tsc",
-    "serve": "nodemon --exec ts-node -r tsconfig-paths/register src/app.ts",
-    "dev": "nodemon --exec ts-node -r tsconfig-paths/register src/app.ts",
+    "start": "node build/app.js",
+    "dev": "nodemon --exec \"yarn build && yarn start\" --watch src --ext ts",
     "test": "jest --detectOpenHandles --forceExit"
   },
   "dependencies": {


### PR DESCRIPTION
path alias 로 인해 `yarn dev` 실행시 build 디렉토리의 코드가 실행되는 bug 가 있습니다.
이를 우회하기 위해 `yarn dev` 스크립트에서 항상 build 후 코드를 실행하도록 수정합니다