### PR TITLE
do not throw error when env file not exists

### DIFF
--- a/src/loaders/env.ts
+++ b/src/loaders/env.ts
@@ -9,6 +9,6 @@ import {resolve} from 'path';
   const envFound = dotenv.config({ path })
 
   if (envFound.error) {
-    throw new Error('couldn\'t find .env file️')
+    console.error("couldn't find .env file")
   }
 })()


### PR DESCRIPTION
.env 파일이 없더라도 에러를 throw 하지 않도록 수정합니다

docker image 내부에 .env 를 직접 copy 하면 안되기 때문에 #58 에서 dockerignore 에 env 를 추가하였습니다.
그로인해 docker image 실행시 .env 가 경로에 없어 에러가 발생하는데 이는 에러가 아니기 때문에 로그만 찍도록 수정하였습니다.

.env 파일이 없더라도 환경변수는 설정되어 있을 수 있기 때문에 이를 확인해야 하며
필요한 환경변수가 없을시 error 를 throw 하는게 맞다고 생각됩니다